### PR TITLE
Removed conflict statement from spec for python-import on Redhat 6

### DIFF
--- a/file_roots/pkg/python-importlib/1_0_2/rhel6/spec/python-importlib.spec
+++ b/file_roots/pkg/python-importlib/1_0_2/rhel6/spec/python-importlib.spec
@@ -4,7 +4,7 @@
 
 Name:           python-importlib
 Version:        1.0.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Backport of importlib.import_module() from Python 2.7
 
 Group:          Development/Languages
@@ -15,7 +15,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:      noarch
 BuildRequires:  python-devel
-Conflicts:      python(abi) = 2.7
+## Conflicts:      python(abi) = 2.7
 
 %description
 This package contains the code from importlib as found in Python 2.7.
@@ -49,5 +49,8 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Thu Mar  3 2016 SaltStack Packaging Team <packaging@saltstack.com> 1.0.2-2
+- Removed Conflict to allow for operation on Amazon Linux
+
 * Tue Jun 21 2011 Andrew Colin Kissa <andrew@topdog.za.net> 1.0.2-1
 - Initial package

--- a/pillar_roots/pkgbuild.sls
+++ b/pillar_roots/pkgbuild.sls
@@ -257,7 +257,7 @@ pkgbuild_registry:
       version: 0.9.14-1
       noarch: True
     python-importlib:
-      version: 1.0.2-1
+      version: 1.0.2-2
       noarch: True
     python-ioflo:
       version: 1.3.8-1

--- a/pillar_roots/versions/2015_8_7/pkgbuild.sls
+++ b/pillar_roots/versions/2015_8_7/pkgbuild.sls
@@ -257,7 +257,7 @@ pkgbuild_registry:
       version: 0.9.14-1
       noarch: True
     python-importlib:
-      version: 1.0.2-1
+      version: 1.0.2-2
       noarch: True
     python-ioflo:
       version: 1.3.8-1


### PR DESCRIPTION
This will allow python-raet to be installed on Amazon Linux, which moved to using python 2.7, which the conflict statement checked for.