### PR TITLE
Work-around for Debian 7 reboot setting env HOME to '/'

### DIFF
--- a/file_roots/setup/debian/debian7/init.sls
+++ b/file_roots/setup/debian/debian7/init.sls
@@ -98,3 +98,10 @@ build_prefs:
     - text: |
         {{prefs_text}}
 
+#36569 work-around reboot Wheezy setting HOME to '/'
+home_env:
+  environ.setenv:
+    - name: HOME
+    - value: /root
+    - update_minion: True
+


### PR DESCRIPTION
Workaround for https://github.com/saltstack/salt/issues/36569