### PR TITLE
Fix install of gpg keys

### DIFF
--- a/file_roots/setup/amazon/init.sls
+++ b/file_roots/setup/amazon/init.sls
@@ -108,9 +108,10 @@ manage_pub_key:
 gpg_load_pub_key:
   module.run:
     - name: gpg.import_key
-    - user: {{build_cfg.build_runas}}
-    - filename: {{pkg_pub_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{build_cfg.build_runas}}
+        filename: {{pkg_pub_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
     - require:
       - file: manage_pub_key
 
@@ -118,9 +119,10 @@ gpg_load_pub_key:
 gpg_load_priv_key:
   module.run:
     - name: gpg.import_key
-    - user: {{build_cfg.build_runas}}
-    - filename: {{pkg_priv_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{build_cfg.build_runas}}
+        filename: {{pkg_priv_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
     - require:
       - module: gpg_load_pub_key
 
@@ -143,10 +145,11 @@ ensure_gpg_rights:
 ensure_pub_gpg_rights:
   module.run:
     - name: file.check_perms
-    - m_name: {{gpg_key_dir}}/gpg_pkg_key.pub
-    - user: {{build_cfg.build_runas}}
-    - group: {{build_cfg.build_runas}}
-    - mode: 644
-    - ret: False
+    - kwargs:
+        m_name: {{gpg_key_dir}}/gpg_pkg_key.pub
+        user: {{build_cfg.build_runas}}
+        group: {{build_cfg.build_runas}}
+        mode: 644
+        ret: False
     - require:
       - file: ensure_gpg_rights

--- a/file_roots/setup/debian/gpg_agent.sls
+++ b/file_roots/setup/debian/gpg_agent.sls
@@ -74,18 +74,20 @@ gpg_agent_start:
 gpg_load_pub_key:
   module.run:
     - name: gpg.import_key
-    - user: {{build_cfg.build_runas}}
-    - filename: {{pkg_pub_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{build_cfg.build_runas}}
+        filename: {{pkg_pub_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
     - require:
       - module: gpg_agent_start
 
 gpg_load_priv_key:
   module.run:
     - name: gpg.import_key
-    - user: {{build_cfg.build_runas}}
-    - filename: {{pkg_priv_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{build_cfg.build_runas}}
+        filename: {{pkg_priv_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
     - require:
       - module: gpg_agent_start
 

--- a/file_roots/setup/redhat/fc24/gpg_agent.sls
+++ b/file_roots/setup/redhat/fc24/gpg_agent.sls
@@ -64,11 +64,12 @@ gpg_agent_conf_file:
 ensure_gpg_conf_rights:
   module.run:
     - name: file.check_perms
-    - m_name: {{gpg_config_file}}
-    - user: {{build_cfg.build_runas}}
-    - group: {{build_cfg.build_runas}}
-    - mode: 644
-    - ret: False
+    - kwargs:
+        m_name: {{gpg_config_file}}
+        user: {{build_cfg.build_runas}}
+        group: {{build_cfg.build_runas}}
+        mode: 644
+        ret: False
     - require:
       - file: gpg_agent_conf_file
 
@@ -76,11 +77,12 @@ e
 nsure_gpg_agent_conf_rights:
   module.run:
     - name: file.check_perms
-    - m_name: {{gpg_agent_config_file}}
-    - user: {{build_cfg.build_runas}}
-    - group: {{build_cfg.build_runas}}
-    - mode: 644
-    - ret: False
+    - kwargs:
+        m_name: {{gpg_agent_config_file}}
+        user: {{build_cfg.build_runas}}
+        group: {{build_cfg.build_runas}}
+        mode: 644
+        ret: False
 
 
 gpg_agent_stop:

--- a/file_roots/setup/redhat/init.sls
+++ b/file_roots/setup/redhat/init.sls
@@ -70,9 +70,10 @@ manage_pub_key:
 gpg_load_pub_key:
   module.run:
     - name: gpg.import_key
-    - user: {{redhat_cfg.build_runas}}
-    - filename: {{pkg_pub_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{redhat_cfg.build_runas}}
+        filename: {{pkg_pub_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
     - require:
       - file: manage_pub_key
 
@@ -80,9 +81,10 @@ gpg_load_pub_key:
 gpg_load_priv_key:
   module.run:
     - name: gpg.import_key
-    - user: {{redhat_cfg.build_runas}}
-    - filename: {{pkg_priv_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{redhat_cfg.build_runas}}
+        filename: {{pkg_priv_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
     - require:
       - module: gpg_load_pub_key
 
@@ -105,11 +107,12 @@ ensure_gpg_rights:
 ensure_pub_gpg_rights:
   module.run:
     - name: file.check_perms
-    - m_name: {{gpg_key_dir}}/gpg_pkg_key.pub
-    - user: {{redhat_cfg.build_runas}}
-    - group: {{redhat_cfg.build_runas}}
-    - mode: 644
-    - ret: False
+    - kwargs:
+        m_name: {{gpg_key_dir}}/gpg_pkg_key.pub
+        user: {{redhat_cfg.build_runas}}
+        group: {{redhat_cfg.build_runas}}
+        mode: 644
+        ret: False
     - require:
       - file: ensure_gpg_rights
 

--- a/file_roots/setup/ubuntu/gpg_agent.sls
+++ b/file_roots/setup/ubuntu/gpg_agent.sls
@@ -126,17 +126,19 @@ gpg_agent_start:
 gpg_load_pub_key:
   module.run:
     - name: gpg.import_key
-    - user: {{build_cfg.build_runas}}
-    - filename: {{pkg_pub_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{build_cfg.build_runas}}
+        filename: {{pkg_pub_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
 
 
 gpg_load_priv_key:
   module.run:
     - name: gpg.import_key
-    - user: {{build_cfg.build_runas}}
-    - filename: {{pkg_priv_key_absfile}}
-    - gnupghome: {{gpg_key_dir}}
+    - kwargs:
+        user: {{build_cfg.build_runas}}
+        filename: {{pkg_priv_key_absfile}}
+        gnupghome: {{gpg_key_dir}}
 
 {% endif %}
 


### PR DESCRIPTION
Installing of gpg keys failed with salt 2016.3.4 and up.
This resolves the issue which was due to using module.run incorrectly