### PR TITLE
Changed user from builder to root for Redhat family 

### DIFF
--- a/file_roots/pkg/python3/3_4/rhel6/init.sls
+++ b/file_roots/pkg/python3/3_4/rhel6/init.sls
@@ -10,7 +10,7 @@
 
 python343:
   pkgbuild.built:
-    - runas: builder
+    - runas: root 
     - results:
       - python34u-3.4.3-2.ius.el6.{{arch_ext}}.rpm
     - dest_dir: /srv/pkgs/rhel6

--- a/file_roots/pkg/python3/3_4/rhel7/init.sls
+++ b/file_roots/pkg/python3/3_4/rhel7/init.sls
@@ -1,6 +1,6 @@
 python343:
   pkgbuild.built:
-    - runas: builder
+    - runas: root
     - results:
       - python34u-3.4.3-2.ius.el7.x86_64.rpm
     - dest_dir: /srv/pkgs/rhel7

--- a/file_roots/setup/base_map.jinja
+++ b/file_roots/setup/base_map.jinja
@@ -1,5 +1,5 @@
 {% set build_dest = pillar.get('build_dest', '/srv/pkgs') %}
-{% set build_runas = pillar.get('build_runas', 'builder') %}
+{% set build_runas = pillar.get('build_runas', 'root') %}
 
 # branch build version
 {% set build_version = pillar.get('build_version', '') %}


### PR DESCRIPTION
Encountered permission issues with the move to branch 2017.7 and given time pressures reverted to using root as user instead of builder as default user, similar to Debian/Ubuntu family