### PR TITLE
Update fix gpg agent for use on Amazon AWS

### DIFF
--- a/file_roots/pkg/zeromq/4_0_5/ubuntu1204/init.sls
+++ b/file_roots/pkg/zeromq/4_0_5/ubuntu1204/init.sls
@@ -1,4 +1,4 @@
-{% import "setup/debian/map.jinja" as buildcfg %}
+{% import "setup/ubuntu/map.jinja" as buildcfg %}
 {% set force = salt['pillar.get']('build_force.all', False) or salt['pillar.get']('build_force.' ~ slspath, False) %}
 
 {% set name = 'zeromq' %}

--- a/file_roots/pkg/zeromq/4_0_5/ubuntu1404/init.sls
+++ b/file_roots/pkg/zeromq/4_0_5/ubuntu1404/init.sls
@@ -1,4 +1,4 @@
-{% import "setup/debian/map.jinja" as buildcfg %}
+{% import "setup/ubuntu/map.jinja" as buildcfg %}
 {% set force = salt['pillar.get']('build_force.all', False) or salt['pillar.get']('build_force.' ~ slspath, False) %}
 
 {% set name = 'zeromq' %}
@@ -11,7 +11,7 @@
 {{name}}-{{version.replace('.', '_')}}:
   pkgbuild.built:
     - runas: {{buildcfg.build_runas}}
-    - results: 
+    - results:
       - {{libname}}_{{version}}{{release_nameadd}}-{{release_ver}}_{{buildcfg.build_arch}}.deb
       - {{libname}}-dbg_{{version}}{{release_nameadd}}-{{release_ver}}_{{buildcfg.build_arch}}.deb
       - {{libname}}-dev_{{version}}{{release_nameadd}}-{{release_ver}}_{{buildcfg.build_arch}}.deb
@@ -20,7 +20,7 @@
       - {{fullname}}_{{version}}{{release_nameadd}}-{{release_ver}}.debian.tar.xz
     - force: {{force}}
     - dest_dir: {{buildcfg.build_dest_dir}}
-    - spec: salt://{{slspath}}/spec/{{fullname}}_{{version}}{{release_nameadd}}-{{release_ver}}.dsc 
+    - spec: salt://{{slspath}}/spec/{{fullname}}_{{version}}{{release_nameadd}}-{{release_ver}}.dsc
     - tgt: {{buildcfg.build_tgt}}
     - template: jinja
     - sources:

--- a/file_roots/setup/debian/gpg_agent.sls
+++ b/file_roots/setup/debian/gpg_agent.sls
@@ -48,11 +48,11 @@
 
 {% set gpg_agent_script_file = build_cfg.build_homedir ~ '/gpg-agent_start.sh' %}
 
-{% set gpg_agent_script_text = 'gpg-agent --homedir ' ~ gpg_key_dir ~ ' ' ~ write_env_file_prefix ~ write_env_file ~ ' --allow-preset-passphrase --max-cache-ttl 300 --daemon
-    GPG_TTY=$(tty)
-    export GPG_TTY
-    echo "GPG_TTY=${GPG_TTY}" > ' ~ gpg_tty_info
-%}
+{% set gpg_agent_script_text = 'gpg-agent --homedir ' ~ gpg_key_dir ~ ' ' ~ write_env_file_prefix ~ write_env_file ~ ' --allow-preset-passphrase --max-cache-ttl 600 --daemon
+        GPG_TTY=$(tty);
+        export GPG_TTY
+        echo "GPG_TTY=${GPG_TTY}" > ' ~ gpg_tty_info ~ '
+' %}
 
 
 gpg_agent_stop:
@@ -140,7 +140,7 @@ gpg_agent_conf_file:
 
 gpg_agent_script_file_exists:
   file.managed:
-    - name: {{gpg_agent_config_file}}
+    - name: {{gpg_agent_script_file}}
     - dir_mode: 755
     - mode: 755
     - show_changes: False
@@ -153,7 +153,7 @@ gpg_agent_script_file_exists:
 
 gpg_agent_start:
   cmd.run:
-   - name:  {{build_cfg.build_homedir}}/{{gpg_agent_script_file}}
+   - name:  {{gpg_agent_script_file}}
    - runas: {{build_cfg.build_runas}}
    - use_vt: True
    - reload_modules: True

--- a/file_roots/setup/debian/gpg_agent.sls
+++ b/file_roots/setup/debian/gpg_agent.sls
@@ -20,7 +20,7 @@
 {% set write_env_file_prefix = '' %}
 {% set write_env_file = '' %}
 {% set pinentry_parms = '
-        pinentry-timeout 20
+        pinentry-timeout 30
         allow-loopback-pinentry' %}
 {% set pinentry_text = 'pinentry-program /usr/bin/pinentry-tty' %}
 {% endif %}
@@ -28,14 +28,14 @@
 {% set pkg_pub_key_absfile = gpg_key_dir ~ '/' ~ pkg_pub_key_file %}
 {% set pkg_priv_key_absfile = gpg_key_dir ~ '/' ~ pkg_priv_key_file %}
 
-{% set gpg_agent_log_file = '/root/gpg-agent.log' %}
+{% set gpg_agent_log_file = build_cfg.build_homedir ~ '/gpg-agent.log' %}
 
 {% set gpg_agent_text = '# enable-ssh-support
         ' ~ write_env_file  ~ '
-        default-cache-ttl 300
-        default-cache-ttl-ssh 300
-        max-cache-ttl 300
-        max-cache-ttl-ssh 300
+        default-cache-ttl 600
+        default-cache-ttl-ssh 600
+        max-cache-ttl 600
+        max-cache-ttl-ssh 600
         allow-preset-passphrase
         daemon
         debug-all
@@ -44,6 +44,14 @@
         verbose
         # PIN entry program
         ' ~ pinentry_text ~ pinentry_parms
+%}
+
+{% set gpg_agent_script_file = build_cfg.build_homedir ~ '/gpg-agent_start.sh' %}
+
+{% set gpg_agent_script_text = 'gpg-agent --homedir ' ~ gpg_key_dir ~ ' ' ~ write_env_file_prefix ~ write_env_file ~ ' --allow-preset-passphrase --max-cache-ttl 300 --daemon
+    GPG_TTY=$(tty)
+    export GPG_TTY
+    echo "GPG_TTY=${GPG_TTY}" > ' ~ gpg_tty_info
 %}
 
 
@@ -64,6 +72,11 @@ gpg_clear_agent_log:
     - name: {{gpg_agent_log_file}}
 
 
+gpg_agent_script_file_rm:
+  file.absent:
+    - name: {{gpg_agent_script_file}}
+
+
 manage_priv_key:
   file.managed:
     - name: {{pkg_priv_key_absfile}}
@@ -72,7 +85,7 @@ manage_priv_key:
     - contents_pillar: gpg_pkg_priv_key
     - show_changes: False
     - user: {{build_cfg.build_runas}}
-    - group: adm
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
 
 
@@ -84,56 +97,68 @@ manage_pub_key:
     - contents_pillar: gpg_pkg_pub_key
     - show_changes: False
     - user: {{build_cfg.build_runas}}
-    - group: adm
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
 
 
 gpg_conf_file_exists:
-  file.touch:
+  file.managed:
     - name: {{gpg_config_file}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
+    - contents: 'use-agent'
 
 
 gpg_tty_file_exists:
-  file.touch:
+  file.managed:
     - name: {{gpg_tty_info}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
-
-
-gpg_conf_file:
-  file.replace:
-    - name: {{gpg_config_file}}
-    - pattern: |
-        ^#\s*use-agent\s*\.*
-    - repl: |
-        use-agent
-    - count: 1
-    - append_if_not_found: True
-    - require:
-      - file: gpg_conf_file_exists
+    - contents: ''
 
 
 gpg_agent_conf_file:
-  file.append:
+  file.managed:
     - name: {{gpg_agent_config_file}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
-    - text: |
+    - contents: |
         {{gpg_agent_text}}
+
+
+gpg_agent_script_file_exists:
+  file.managed:
+    - name: {{gpg_agent_config_file}}
+    - dir_mode: 755
+    - mode: 755
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - makedirs: True
+    - contents: |
+        {{gpg_agent_script_text}}
 
 
 gpg_agent_start:
   cmd.run:
-    - name: |
-        eval $(gpg-agent --homedir {{gpg_key_dir}} {{write_env_file_prefix}}{{write_env_file}} --allow-preset-passphrase --max-cache-ttl 300 --daemon)
-        GPG_TTY=$(tty)
-        export GPG_TTY
-        echo "GPG_TTY=${GPG_TTY}" > {{gpg_tty_info}}
-#    - python_shell: True
-    - use_vt: True
-    - runas: {{build_cfg.build_runas}}
-    - reload_modules: True
-    - require:
-      - cmd: gpg_agent_stop
+   - name:  {{build_cfg.build_homedir}}/{{gpg_agent_script_file}}
+   - runas: {{build_cfg.build_runas}}
+   - use_vt: True
+   - reload_modules: True
+   - require:
+     - cmd: gpg_agent_stop
 
 
 gpg_load_pub_key:

--- a/file_roots/setup/debian/map.jinja
+++ b/file_roots/setup/debian/map.jinja
@@ -3,7 +3,8 @@
 
 # Get the user under which to build
 {# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
-{% set build_runas = 'root' %}
+## {# {% set build_runas = 'root' %} #}
+{% set build_runas = 'admin' %}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/debian/map.jinja
+++ b/file_roots/setup/debian/map.jinja
@@ -2,9 +2,9 @@
 {% import "setup/base_map.jinja" as basecfg %}
 
 # Get the user under which to build
-{# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
+{% set build_runas = pillar.get('build_runas', basecfg.build_runas) %}
 ## {# {% set build_runas = 'root' %} #}
-{% set build_runas = 'admin' %}
+## {# {% set build_runas = 'admin' %} #}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/ubuntu/gpg_agent.sls
+++ b/file_roots/setup/ubuntu/gpg_agent.sls
@@ -20,7 +20,7 @@
 {% set write_env_file_prefix = '' %}
 {% set write_env_file = '' %}
 {% set pinentry_parms = '
-        pinentry-timeout 20
+        pinentry-timeout 30
         allow-loopback-pinentry' %}
 {% set pinentry_text = 'pinentry-program /usr/bin/pinentry-tty' %}
 {% endif %}
@@ -32,10 +32,10 @@
 
 {% set gpg_agent_text = '# enable-ssh-support
         ' ~ write_env_file  ~ '
-        default-cache-ttl 300
-        default-cache-ttl-ssh 300
-        max-cache-ttl 300
-        max-cache-ttl-ssh 300
+        default-cache-ttl 600
+        default-cache-ttl-ssh 600
+        max-cache-ttl 600
+        max-cache-ttl-ssh 600
         allow-preset-passphrase
         daemon
         debug-all
@@ -46,6 +46,13 @@
         ' ~ pinentry_text ~ pinentry_parms
 %}
 
+{% set gpg_agent_script_file = build_cfg.build_homedir ~ '/gpg-agent_start.sh' %}
+
+{% set gpg_agent_script_text = 'gpg-agent --homedir ' ~ gpg_key_dir ~ ' ' ~ write_env_file_prefix ~ write_env_file ~ ' --allow-preset-passphrase --max-cache-ttl 600 --daemon
+        GPG_TTY=$(tty);
+        export GPG_TTY
+        echo "GPG_TTY=${GPG_TTY}" > ' ~ gpg_tty_info ~ '
+' %}
 
 
 gpg_agent_stop:
@@ -63,6 +70,11 @@ gpg_dir_rm:
 gpg_clear_agent_log:
   file.absent:
     - name: {{gpg_agent_log_file}}
+
+
+gpg_agent_script_file_rm:
+  file.absent:
+    - name: {{gpg_agent_script_file}}
 
 
 manage_priv_key:
@@ -90,51 +102,63 @@ manage_pub_key:
 
 
 gpg_conf_file_exists:
-  file.touch:
+  file.managed:
     - name: {{gpg_config_file}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
+    - contents: 'use-agent'
 
 
 gpg_tty_file_exists:
-  file.touch:
+  file.managed:
     - name: {{gpg_tty_info}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
-
-
-gpg_conf_file:
-  file.replace:
-    - name: {{gpg_config_file}}
-    - pattern: |
-        ^#\s*use-agent\s*\.*
-    - repl: |
-        use-agent
-    - count: 1
-    - append_if_not_found: True
-    - require:
-      - file: gpg_conf_file_exists
+    - contents: ''
 
 
 gpg_agent_conf_file:
-  file.append:
+  file.managed:
     - name: {{gpg_agent_config_file}}
+    - dir_mode: 700
+    - mode: 644
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
     - makedirs: True
-    - text: |
+    - contents: |
         {{gpg_agent_text}}
+
+
+gpg_agent_script_file_exists:
+  file.managed:
+    - name: {{gpg_agent_script_file}}
+    - dir_mode: 755
+    - mode: 755
+    - show_changes: False
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - makedirs: True
+    - contents: |
+        {{gpg_agent_script_text}}
 
 
 gpg_agent_start:
   cmd.run:
-    - name: |
-        eval $(gpg-agent --homedir {{gpg_key_dir}} {{write_env_file_prefix}}{{write_env_file}} --allow-preset-passphrase --max-cache-ttl 300 --daemon)
-        GPG_TTY=$(tty)
-        export GPG_TTY
-        echo "GPG_TTY=${GPG_TTY}" > {{gpg_tty_info}}
-#    - python_shell: True
-    - use_vt: True
-    - runas: {{build_cfg.build_runas}}
-    - reload_modules: True
-    - require:
-      - cmd: gpg_agent_stop
+   - name:  {{gpg_agent_script_file}}
+   - runas: {{build_cfg.build_runas}}
+   - use_vt: True
+   - reload_modules: True
+   - require:
+     - cmd: gpg_agent_stop
 
 
 gpg_load_pub_key:

--- a/file_roots/setup/ubuntu/gpg_agent.sls
+++ b/file_roots/setup/ubuntu/gpg_agent.sls
@@ -28,7 +28,7 @@
 {% set pkg_pub_key_absfile = gpg_key_dir ~ '/' ~ pkg_pub_key_file %}
 {% set pkg_priv_key_absfile = gpg_key_dir ~ '/' ~ pkg_priv_key_file %}
 
-{% set gpg_agent_log_file = '/root/gpg-agent.log' %}
+{% set gpg_agent_log_file = build_cfg.build_homedir ~ '/gpg-agent.log' %}
 
 {% set gpg_agent_text = '# enable-ssh-support
         ' ~ write_env_file  ~ '

--- a/file_roots/setup/ubuntu/map.jinja
+++ b/file_roots/setup/ubuntu/map.jinja
@@ -3,7 +3,8 @@
 
 # Get the user under which to build
 {# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
-{% set build_runas = 'root' %}
+## {# {% set build_runas = 'root' %} #}
+{% set build_runas = 'ubuntu' %}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/ubuntu/map.jinja
+++ b/file_roots/setup/ubuntu/map.jinja
@@ -3,8 +3,8 @@
 
 # Get the user under which to build
 {# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
-## {# {% set build_runas = 'root' %} #}
-{% set build_runas = 'ubuntu' %}
+{% set build_runas = 'root' %}
+## {# {% set build_runas = 'ubuntu' %} #}
 
 # Get the repo signing timeout
 {% set repo_sign_timeout = basecfg.repo_sign_timeout %}

--- a/file_roots/setup/ubuntu/map.jinja
+++ b/file_roots/setup/ubuntu/map.jinja
@@ -2,8 +2,8 @@
 {% import "setup/base_map.jinja" as basecfg %}
 
 # Get the user under which to build
-{# {% set build_runas = pillar.get('build_runas', basecfg.build_runas) %} #}
-{% set build_runas = 'root' %}
+{% set build_runas = pillar.get('build_runas', basecfg.build_runas) %}
+## {# {% set build_runas = 'root' %} #}
 ## {# {% set build_runas = 'ubuntu' %} #}
 
 # Get the repo signing timeout

--- a/file_roots/setup/ubuntu/ubuntu1404/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1404/init.sls
@@ -84,32 +84,6 @@ build_prefs_rm:
     - name: /etc/apt/preferences
 
 
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << EOF
-        {{prefs_text}}
-        EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
-
-
 build_pbldhooks_perms:
   file.directory:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/
@@ -123,10 +97,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
 

--- a/file_roots/setup/ubuntu/ubuntu1404/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1404/init.sls
@@ -71,7 +71,7 @@ build_pbldhooks_rm_G05:
 
 build_pbldhooks_rm_D04:
   file.absent:
-    - name: {{build_cfg.build_homedir}}t/.pbuilder-hooks/D04update_local_repo
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
 
 
 build_pbldrc_rm:

--- a/file_roots/setup/ubuntu/ubuntu1604/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1604/init.sls
@@ -65,6 +65,7 @@ build_additional_py3_pkgs:
       - apt-utils
 {% endif %}
 
+
 build_pbldhooks_rm_G05:
   file.absent:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
@@ -85,32 +86,6 @@ build_prefs_rm:
     - name: /etc/apt/preferences
 
 
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << EOF
-        {{prefs_text}}
-        EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
-
-
 build_pbldhooks_perms:
   file.directory:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/
@@ -124,10 +99,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
 

--- a/file_roots/setup/ubuntu/ubuntu1804/init.sls
+++ b/file_roots/setup/ubuntu/ubuntu1804/init.sls
@@ -41,6 +41,7 @@ include:
   - setup.ubuntu
   - setup.ubuntu.gpg_agent
 
+
 build_additional_pkgs:
   pkg.installed:
     - pkgs:
@@ -66,6 +67,7 @@ build_additional_py3_pkgs:
       - apt-utils
 {% endif %}
 
+
 build_pbldhooks_rm_G05:
   file.absent:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
@@ -86,32 +88,6 @@ build_prefs_rm:
     - name: /etc/apt/preferences
 
 
-build_pbldhooks_file_G05:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        set -e
-        cat > "/etc/apt/preferences" << EOF
-        {{prefs_text}}
-        EOF
-
-
-build_pbldhooks_file_D04:
-  file.append:
-    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
-    - makedirs: True
-    - text: |
-        #!/bin/sh
-        # path to local repo
-        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
-        # Generate a Packages file
-        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
-        # Update to include any new packagers in the local repo
-        apt-get --allow-unauthenticated update
-
-
 build_pbldhooks_perms:
   file.directory:
     - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/
@@ -125,10 +101,49 @@ build_pbldhooks_perms:
         - mode
 
 
+build_pbldhooks_file_G05:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/G05apt-preferences
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        set -e
+        cat > "/etc/apt/preferences" << @EOF
+        {{prefs_text}}
+        @EOF
+
+
+build_pbldhooks_file_D04:
+  file.managed:
+    - name: {{build_cfg.build_homedir}}/.pbuilder-hooks/D04update_local_repo
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
+        #!/bin/sh
+        # path to local repo
+        LOCAL_REPO="{{build_cfg.build_dest_dir}}"
+        # Generate a Packages file
+        ( cd ${LOCAL_REPO} ; /usr/bin/apt-ftparchive packages . > "${LOCAL_REPO}/Packages" )
+        # Update to include any new packagers in the local repo
+        apt-get --allow-unauthenticated update
+
+
 build_pbldrc:
-  file.append:
+  file.managed:
     - name: {{build_cfg.build_homedir}}/.pbuilderrc
-    - text: |
+    - makedirs: True
+    - dir_mode: 0755
+    - mode: 0775
+    - user: {{build_cfg.build_runas}}
+    - group: {{build_cfg.build_runas}}
+    - contents: |
         DIST="{{os_codename}}"
         LOCAL_REPO="{{build_cfg.build_dest_dir}}"
 


### PR DESCRIPTION
Needed to allow for non-root user for Debian 9 (and 8 and Ubuntu 18.04 by association) on Amazon AWS.

These changes also require up coming Fluorine based Salt debbuild.py