### PR TITLE
Adjust Python 2 dependencies and adjust spec files for RHEL 7

### DIFF
--- a/file_roots/pkg/salt/2017_7/rhel7/spec/salt.spec
+++ b/file_roots/pkg/salt/2017_7/rhel7/spec/salt.spec
@@ -91,7 +91,11 @@ Requires: yum-utils
 
 %if ((0%{?rhel} >= 6 || 0%{?fedora} > 12) && 0%{?include_tests})
 BuildRequires: python%{?__python_ver}-tornado >= 4.2.1
+%if (0%{?rhel} >= 7)
+BuildRequires: python2-futures >= 2.0
+%else
 BuildRequires: python%{?__python_ver}-futures >= 2.0
+%endif
 BuildRequires: python%{?__python_ver}-crypto >= 2.6.1
 BuildRequires: python%{?__python_ver}-jinja2
 BuildRequires: python%{?__python_ver}-msgpack >= 0.4
@@ -146,7 +150,11 @@ Requires: python%{?__python_ver}-requests >= 1.0.0
 Requires: python%{?__python_ver}-zmq
 Requires: python%{?__python_ver}-markupsafe
 Requires: python%{?__python_ver}-tornado >= 4.2.1, python%{?__python_ver}-tornado < 6.0
+%if (0%{?rhel} >= 7)
+Requires: python2-futures >= 2.0
+%else
 Requires: python%{?__python_ver}-futures >= 2.0
+%endif
 Requires: python%{?__python_ver}-six
 Requires: python%{?__python_ver}-psutil
 
@@ -624,7 +632,7 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
-- Revised versions of cherrypy acceptable
+- Revised acceptable versions of cherrypy, futures
 
 * Thu Jun 07 2018 SaltStack Packaging Team <packaging@saltstack.com> - 2017.7.6-1
 - Update to feature release 2017.7.6-1  for Python 2

--- a/file_roots/pkg/salt/2018_11/rhel7/spec/salt.spec
+++ b/file_roots/pkg/salt/2018_11/rhel7/spec/salt.spec
@@ -92,7 +92,11 @@ Requires: yum-utils
 
 %if ((0%{?rhel} >= 6 || 0%{?fedora} > 12) && 0%{?include_tests})
 BuildRequires: python%{?__python_ver}-tornado >= 4.2.1
+%if (0%{?rhel} >= 7)
+BuildRequires: python2-futures >= 2.0
+%else
 BuildRequires: python%{?__python_ver}-futures >= 2.0
+%endif
 BuildRequires: python%{?__python_ver}-crypto >= 2.6.1
 BuildRequires: python%{?__python_ver}-jinja2
 BuildRequires: python%{?__python_ver}-msgpack >= 0.4
@@ -146,8 +150,12 @@ Requires: PyYAML
 Requires: python%{?__python_ver}-requests >= 1.0.0
 Requires: python%{?__python_ver}-zmq
 Requires: python%{?__python_ver}-markupsafe
-Requires: python%{?__python_ver}-tornado >= 4.2.1, python%{?__python_ver}-tornado < 6.0 
+Requires: python%{?__python_ver}-tornado >= 4.2.1, python%{?__python_ver}-tornado < 6.0
+%if (0%{?rhel} >= 7)
+Requires: python2-futures >= 2.0
+%else
 Requires: python%{?__python_ver}-futures >= 2.0
+%endif
 Requires: python%{?__python_ver}-six
 Requires: python%{?__python_ver}-psutil
 
@@ -615,7 +623,7 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
-- Revised versions of cherrypy acceptable
+- Revised acceptable versions of cherrypy, futures
 
 * Wed Aug 08 2018 SaltStack Packaging Team <packaging@saltstack.com> - 2018.11.0-0
 - Update to feature release branch 2018.11.0-0 for Python 2

--- a/file_roots/pkg/salt/2018_3/rhel7/spec/salt.spec
+++ b/file_roots/pkg/salt/2018_3/rhel7/spec/salt.spec
@@ -92,7 +92,11 @@ Requires: yum-utils
 
 %if ((0%{?rhel} >= 6 || 0%{?fedora} > 12) && 0%{?include_tests})
 BuildRequires: python%{?__python_ver}-tornado >= 4.2.1
+%if (0%{?rhel} >= 7)
+BuildRequires: python2-futures >= 2.0
+%else
 BuildRequires: python%{?__python_ver}-futures >= 2.0
+%endif
 BuildRequires: python%{?__python_ver}-crypto >= 2.6.1
 BuildRequires: python%{?__python_ver}-jinja2
 BuildRequires: python%{?__python_ver}-msgpack >= 0.4
@@ -147,7 +151,11 @@ Requires: python%{?__python_ver}-requests >= 1.0.0
 Requires: python%{?__python_ver}-zmq
 Requires: python%{?__python_ver}-markupsafe
 Requires: python%{?__python_ver}-tornado >= 4.2.1, python%{?__python_ver}-tornado < 6.0 
+%if (0%{?rhel} >= 7)
+Requires: python2-futures >= 2.0
+%else
 Requires: python%{?__python_ver}-futures >= 2.0
+%endif
 Requires: python%{?__python_ver}-six
 Requires: python%{?__python_ver}-psutil
 
@@ -617,7 +625,7 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
-- Revised versions of cherrypy acceptable
+- Revised acceptable versions of cherrypy, futures
 
 * Thu Jun 21 2018 SaltStack Packaging Team <packaging@saltstack.com> - 2018.3.2-1
 - Update to feature release 2018.3.2-1  for Python 2

--- a/file_roots/versions/2017_7/debian_pkg.sls
+++ b/file_roots/versions/2017_7/debian_pkg.sls
@@ -39,26 +39,26 @@ include:
 
 {% else %}
     - pkg.libsodium.1_0_3.debian8
-    - pkg.python-cherrypy.2_3_0.debian8
-    - pkg.python-croniter.0_3_4.debian8
-    - pkg.python-crypto.2_6_1.debian8
-    - pkg.python-enum34.1_0_4.debian8
-    - pkg.python-future.0_14_3.debian8
+##    - pkg.python-cherrypy.2_3_0.debian8   ## jessie 2.3.0-3
+##    - pkg.python-croniter.0_3_4.debian8   ## jessie 0.3.4-1, jessie-backports 0.3.12-1~bpo8+1
+##    - pkg.python-crypto.2_6_1.debian8     ## jessie 2.6.1-5+deb8u1
+##    - pkg.python-enum34.1_0_4.debian8     ## jessie 1.0.3-1
+##    - pkg.python-future.0_14_3.debian8    ## jessie 0.15.2-4~bpo8+1
     - pkg.python-futures.3_0_3.debian8
     - pkg.python-ioflo.1_3_8.debian8
     - pkg.python-jinja2.2_9_4.debian8
     - pkg.python-libcloud.1_5_0.debian8
     - pkg.python-libnacl.4_1.debian8
-    - pkg.python-msgpack.0_4_2.debian8
-    - pkg.python-pyzmq.14_4_0.debian8
+##    - pkg.python-msgpack.0_4_2.debian8    ## jessie 0.4.2-1, jessie-backports 0.4.6-1~bpo8+1
+##    - pkg.python-pyzmq.14_4_0.debian8     ## jessie 14.4.0-1
     - pkg.python-raet.0_6_3.debian8
-    - pkg.python-systemd.231.debian8
+##    - pkg.python-systemd.231.debian8      ## jessie 233-1~bpo8+1
     - pkg.python-timelib.0_2_4.debian8
     - pkg.python-tornado.4_2_1.debian8
     - pkg.python-urllib3.1_10_4.debian8
-    - pkg.python-yaml.3_11.debian8
+##    - pkg.python-yaml.3_11.debian8        ## jessie 3.11-2
     - pkg.salt.2017_7.debian8
-    - pkg.zeromq.4_0_5.debian8
+##    - pkg.zeromq.4_0_5.debian8            ## jessie libzmq3 4.0.5+dfsg-2+deb8u1
 
 {% endif %}
 

--- a/file_roots/versions/2017_7/redhat_pkg.sls
+++ b/file_roots/versions/2017_7/redhat_pkg.sls
@@ -4,15 +4,15 @@ include:
 {% if buildcfg.build_release == 'rhel7' %}
 
     - pkg.libsodium.1_0_16.rhel7
-    - pkg.libtomcrypt.1_17.rhel7
-    - pkg.libtommath.0_42_0.rhel7
+##    - pkg.libtomcrypt.1_17.rhel7     ## extras   1.17-26.el7
+##    - pkg.libtommath.0_42_0.rhel7    ## extras   0.42.0-6.el7
     - pkg.openpgm.5_2_122.rhel7
-    - pkg.python-chardet.2_2_1.rhel7
+##    - pkg.python-chardet.2_2_1.rhel7  ## base     2.2.1-1.el7_1
     - pkg.python-cherrypy.5_6_0.rhel7
     - pkg.python-crypto.2_6_1.rhel7
     - pkg.python-pycryptodome.3_6_1.rhel7
-    - pkg.python-enum34.1_0.rhel7
-    - pkg.python-futures.3_0_3.rhel7
+##    - pkg.python-enum34.1_0.rhel7     ## base     1.0.4-1.el7
+##    - pkg.python-futures.3_0_3.rhel7  ## base     python2-futures     3.1.1-5.el7
     - pkg.python-ioflo.1_3_8.rhel7
     - pkg.python-libcloud.2_0_0.rhel7
     - pkg.python-libnacl.1_6_1.rhel7
@@ -22,9 +22,9 @@ include:
     - pkg.python-pyzmq.15_3_0.rhel7
     - pkg.python-raet.0_6_5.rhel7
     - pkg.python-simplejson.3_3_3.rhel7
-    - pkg.python-tornado.4_2_1.rhel7
+##    - pkg.python-tornado.4_2_1.rhel7  ## base     4.2.1-4.el7
     - pkg.python-timelib.0_2_4.rhel7
-    - pkg.python-urllib3.1_10_2.rhel7
+##    - pkg.python-urllib3.1_10_2.rhel7 ## base     1.10.2-2.el7_1  available 1.10.2-5.el7
     - pkg.python-yaml.3_11.rhel7
     - pkg.salt.2017_7.rhel7
     - pkg.zeromq.4_1_4.rhel7

--- a/file_roots/versions/2017_7/ubuntu_pkg.sls
+++ b/file_roots/versions/2017_7/ubuntu_pkg.sls
@@ -10,13 +10,13 @@ include:
 
 {% elif buildcfg.build_release == 'ubuntu1604' %}
 
-    - pkg.libsodium.1_0_8.ubuntu1604
+##    - pkg.libsodium.1_0_8.ubuntu1604      ## xenial libsodium18 1.0.8-5
     - pkg.python-ioflo.1_5_0.ubuntu1604
     - pkg.python-libcloud.1_5_0.ubuntu1604
     - pkg.python-libnacl.4_1.ubuntu1604
     - pkg.python-raet.0_6_5.ubuntu1604
     - pkg.python-timelib.0_2_4.ubuntu1604
-    - pkg.python-tornado.4_2_1.ubuntu1604
+##    - pkg.python-tornado.4_2_1.ubuntu1604 ## xenial 4.2.1-1ubuntu3
     - pkg.salt.2017_7.ubuntu1604
 
 {% elif buildcfg.build_release == 'ubuntu1404' %}

--- a/file_roots/versions/2018_11/debian_pkg.sls
+++ b/file_roots/versions/2018_11/debian_pkg.sls
@@ -48,7 +48,7 @@ include:
     - pkg.python-urllib3.1_10_4.debian8     ## jessie 1.9.1-3, jessie-backports 1.16-1~bpo8+1
 ##    - pkg.python-yaml.3_11.debian8        ## jessie 3.11-2
     - pkg.salt.2018_11.debian8
-    - pkg.zeromq.4_0_5.debian8              ## jessie libzmq3 4.0.5+dfsg-2+deb8u1
+##    - pkg.zeromq.4_0_5.debian8            ## jessie libzmq3 4.0.5+dfsg-2+deb8u1
 
 {% endif %}
 

--- a/file_roots/versions/2018_11/redhat_pkg.sls
+++ b/file_roots/versions/2018_11/redhat_pkg.sls
@@ -7,7 +7,7 @@ include:
 ##     - pkg.libtomcrypt.1_17.rhel7     ## extras   1.17-26.el7
 ##     - pkg.libtommath.0_42_0.rhel7    ## extras   0.42.0-6.el7
     - pkg.openpgm.5_2_122.rhel7         ## EPEL     5.2.122-2.el7
-##    - pkg.openssl.1_0_2k.rhel7        ## base     1:1.0.2k-16.el7
+    - pkg.openssl.1_0_2k.rhel7        ## base     1:1.0.2k-16.el7
 ##    - pkg.python-chardet.2_2_1.rhel7  ## base     2.2.1-1.el7_1
     - pkg.python-cherrypy.5_6_0.rhel7   ## base     3.2.2-4.el7
     - pkg.python-crypto.2_6_1.rhel7     ## extras   2.6.1-1.el7.centos

--- a/file_roots/versions/2018_3/debian_pkg.sls
+++ b/file_roots/versions/2018_3/debian_pkg.sls
@@ -39,26 +39,26 @@ include:
 
 {% else %}
     - pkg.libsodium.1_0_3.debian8
-    - pkg.python-cherrypy.2_3_0.debian8
-    - pkg.python-croniter.0_3_4.debian8
-    - pkg.python-crypto.2_6_1.debian8
-    - pkg.python-enum34.1_0_4.debian8
-    - pkg.python-future.0_14_3.debian8
+##    - pkg.python-cherrypy.2_3_0.debian8   ## jessie 2.3.0-3
+##    - pkg.python-croniter.0_3_4.debian8   ## jessie 0.3.4-1, jessie-backports 0.3.12-1~bpo8+1
+##    - pkg.python-crypto.2_6_1.debian8     ## jessie 2.6.1-5+deb8u1
+##    - pkg.python-enum34.1_0_4.debian8     ## jessie 1.0.3-1
+##    - pkg.python-future.0_14_3.debian8    ## jessie 0.15.2-4~bpo8+1
     - pkg.python-futures.3_0_3.debian8
     - pkg.python-ioflo.1_3_8.debian8
     - pkg.python-jinja2.2_9_4.debian8
     - pkg.python-libcloud.1_5_0.debian8
     - pkg.python-libnacl.4_1.debian8
-    - pkg.python-msgpack.0_4_2.debian8
-    - pkg.python-pyzmq.14_4_0.debian8
+##    - pkg.python-msgpack.0_4_2.debian8    ## jessie 0.4.2-1, jessie-backports 0.4.6-1~bpo8+1
+##    - pkg.python-pyzmq.14_4_0.debian8     ## jessie 14.4.0-1
     - pkg.python-raet.0_6_3.debian8
-    - pkg.python-systemd.231.debian8
+##    - pkg.python-systemd.231.debian8      ## jessie 233-1~bpo8+1
     - pkg.python-timelib.0_2_4.debian8
     - pkg.python-tornado.4_2_1.debian8
     - pkg.python-urllib3.1_10_4.debian8
-    - pkg.python-yaml.3_11.debian8
+##    - pkg.python-yaml.3_11.debian8        ## jessie 3.11-2
     - pkg.salt.2018_3.debian8
-    - pkg.zeromq.4_0_5.debian8
+##    - pkg.zeromq.4_0_5.debian8            ## jessie libzmq3 4.0.5+dfsg-2+deb8u1
 
 {% endif %}
 

--- a/file_roots/versions/2018_3/redhat_pkg.sls
+++ b/file_roots/versions/2018_3/redhat_pkg.sls
@@ -4,16 +4,16 @@ include:
 {% if buildcfg.build_release == 'rhel7' %}
 
     - pkg.libsodium.1_0_16.rhel7
-    - pkg.libtomcrypt.1_17.rhel7
-    - pkg.libtommath.0_42_0.rhel7
+##    - pkg.libtomcrypt.1_17.rhel7     ## extras   1.17-26.el7
+##    - pkg.libtommath.0_42_0.rhel7    ## extras   0.42.0-6.el7
     - pkg.openpgm.5_2_122.rhel7
     - pkg.openssl.1_0_2k.rhel7
-    - pkg.python-chardet.2_2_1.rhel7
+##    - pkg.python-chardet.2_2_1.rhel7  ## base     2.2.1-1.el7_1
     - pkg.python-cherrypy.5_6_0.rhel7
     - pkg.python-crypto.2_6_1.rhel7
     - pkg.python-pycryptodome.3_6_1.rhel7
-    - pkg.python-enum34.1_0.rhel7
-    - pkg.python-futures.3_0_3.rhel7
+##    - pkg.python-enum34.1_0.rhel7     ## base     1.0.4-1.el7
+##    - pkg.python-futures.3_0_3.rhel7  ## base     python2-futures     3.1.1-5.el7
     - pkg.python-ioflo.1_3_8.rhel7
     - pkg.python-libcloud.2_0_0.rhel7
     - pkg.python-libnacl.1_6_1.rhel7
@@ -25,9 +25,9 @@ include:
     - pkg.python-raet.0_6_5.rhel7
     - pkg.python-simplejson.3_3_3.rhel7
     - pkg.python-timelib.0_2_4.rhel7
-    - pkg.python-tornado.4_2_1.rhel7
+##    - pkg.python-tornado.4_2_1.rhel7  ## base     4.2.1-4.el7
     - pkg.python-typing.3_5_2_2.rhel7
-    - pkg.python-urllib3.1_10_2.rhel7
+##    - pkg.python-urllib3.1_10_2.rhel7 ## base     1.10.2-2.el7_1  available 1.10.2-5.el7
     - pkg.python-yaml.3_11.rhel7
     - pkg.salt.2018_3.rhel7
     - pkg.zeromq.4_1_4.rhel7

--- a/file_roots/versions/2018_3/ubuntu_pkg.sls
+++ b/file_roots/versions/2018_3/ubuntu_pkg.sls
@@ -10,13 +10,13 @@ include:
 
 {% elif buildcfg.build_release == 'ubuntu1604' %}
 
-    - pkg.libsodium.1_0_8.ubuntu1604
+##    - pkg.libsodium.1_0_8.ubuntu1604      ## xenial libsodium18 1.0.8-5
     - pkg.python-ioflo.1_5_0.ubuntu1604
     - pkg.python-libcloud.1_5_0.ubuntu1604
     - pkg.python-libnacl.4_1.ubuntu1604
     - pkg.python-raet.0_6_5.ubuntu1604
     - pkg.python-timelib.0_2_4.ubuntu1604
-    - pkg.python-tornado.4_2_1.ubuntu1604
+##    - pkg.python-tornado.4_2_1.ubuntu1604 ## xenial 4.2.1-1ubuntu3
     - pkg.salt.2018_3.ubuntu1604
 
 {% elif buildcfg.build_release == 'ubuntu1404' %}


### PR DESCRIPTION
Based on review of current minimum supported platforms:
RHEL 7.2
Debian 8.7, 9.0
Ubuntu 18.04, 16.04. 14.04.5

Removed dependencies which are provided by the platform at the same or higher version